### PR TITLE
[OPS-1406] Update push-scan job to use all-build-push-scan-harbor.yml

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   push-scan:
-    uses: mconf/mconf-ci-jobs/.github/workflows/lb-push-scan-image.yml@main
+    uses: mconf/mconf-ci-jobs/.github/workflows/all-build-push-scan-harbor.yml@main
     secrets: inherit
     with:
       runs-on: '["ubuntu-22.04"]'
+      image_name: aws-batch-exporter
+      organization: ops
+      trivy-scanners: "vuln,config"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a new shared CI template and adds configuration options for image scanning and publishing.

**CI/CD workflow updates:**

* Updated the `push-scan` job in `.github/workflows/push-image.yml` to use `all-build-push-scan-harbor.yml` instead of `lb-push-scan-image.yml`, reflecting a shift to a more general-purpose workflow.
* Added new input parameters to the job: `image_name` set to `aws-batch-exporter`, `organization` set to `ops`, and `trivy-scanners` set to `"vuln,config"`, enabling more precise control over image naming, organization, and security scanning configuration.